### PR TITLE
Bugfix in version 2.x implementation

### DIFF
--- a/2.x/AFHTTPRequestOperationManager+Synchronous.m
+++ b/2.x/AFHTTPRequestOperationManager+Synchronous.m
@@ -31,7 +31,7 @@
                        operation:(AFHTTPRequestOperation *__autoreleasing *)operationPtr
                            error:(NSError *__autoreleasing *)outError {
 
-    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"GET" URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters error:nil];
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString] parameters:parameters error:nil];
 
     AFHTTPRequestOperation *op = [self HTTPRequestOperationWithRequest:request
                                                                success:nil


### PR DESCRIPTION
Bug fixed in the ```requestWithMethod:URLString:parameters:error:``` method.

The original code sent every request as a GET request and ignored the method parameter.